### PR TITLE
Service enable button disabled while state is changing

### DIFF
--- a/WindowsServicePanel/Sevices/WindowsServiceMonitor.cs
+++ b/WindowsServicePanel/Sevices/WindowsServiceMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ServiceProcess;
+using System.Threading.Tasks;
 using Microsoft.Win32;
 
 namespace WindowsServicePanel.Sevices
@@ -108,33 +109,38 @@ namespace WindowsServicePanel.Sevices
         /// Start the Windows service, a timeout exception will be thrown when the service
         /// does not start in one minute.
         /// </summary>
-        public void Start()
+        public async Task Start()
         {
             if (_service.Status != ServiceControllerStatus.Running ||
             _service.Status != ServiceControllerStatus.StartPending)
                 _service.Start();
 
-            _service.WaitForStatus(ServiceControllerStatus.Running, new TimeSpan(0, 0, 1, 0));
+            await Task.Run(() => {
+                _service.WaitForStatus(ServiceControllerStatus.Running, new TimeSpan(0, 0, 1, 0));
+            });
+            
         }
 
         /// <summary>
         /// Stop the Windows service, a timeout exception will be thrown when the service
         /// does not start in one minute.
         /// </summary>
-        public void Stop()
+        public async Task Stop()
         {
             _service.Stop();
-            _service.WaitForStatus(ServiceControllerStatus.Stopped, new TimeSpan(0, 0, 1, 0));
+            await Task.Run(() => {
+                _service.WaitForStatus(ServiceControllerStatus.Stopped, new TimeSpan(0, 0, 1, 0));
+            });
         }
 
         /// <summary>
         /// Restart the Windows service, a timeout exception will be thrown when the service
         /// does not stop or start in one minute.
         /// </summary>
-        public void Restart()
+        public async Task Restart()
         {
-            Stop();
-            Start();
+            await Stop();
+            await Start();
         }
     }
 }

--- a/WindowsServicePanel/Xaml/MainWindow/ServicePane.xaml
+++ b/WindowsServicePanel/Xaml/MainWindow/ServicePane.xaml
@@ -16,7 +16,10 @@
                 <ColumnDefinition Width="100" />
             </Grid.ColumnDefinitions>
             <TextBlock FontSize="20" VerticalAlignment="Center" Text="{Binding ElementName=ServicePaneRoot, Path=ServiceName, Mode=OneWay}" />
-            <wpfSpark:ToggleSwitch x:Name="ServiceButton" IsChecked="{Binding ElementName=ServicePaneRoot, Path=Running, Mode=TwoWay}" Grid.Column="1" Command="{Binding ChangeServiceStatusCommand}"
+            <wpfSpark:ToggleSwitch x:Name="ServiceButton"
+                                   IsChecked="{Binding ElementName=ServicePaneRoot, Path=Running, Mode=TwoWay}"
+                                   IsEnabled="{Binding ReadyToChange, Mode=OneWay}"
+                                   Grid.Column="1" Command="{Binding ChangeServiceStatusCommand}"
                        Style="{StaticResource {ComponentResourceKey TypeInTargetAssembly=wpfSpark:ToggleSwitch, ResourceId=ToggleSwitch.UWP.Dark.Style}}"/>
             <TextBlock Grid.Column="2" FontSize="20" VerticalAlignment="Center" HorizontalAlignment="Center"
                        Text="{Binding Running, Converter={StaticResource ConverterBooleanToRunningStopped}, Mode=OneWay}"/>


### PR DESCRIPTION
It can take a few seconds to start or stop a service. During this time it was possible to click the button more than once.

This disables the button while the service is changing status.

Part of issue #15 